### PR TITLE
Update run-rt-estimate.R

### DIFF
--- a/rt-estimate/estimate/utils/rt-data-defaults.R
+++ b/rt-estimate/estimate/utils/rt-data-defaults.R
@@ -33,8 +33,8 @@ setup_future <- function(jobs) {
   }
   
   
-  plan(tweak(multiprocess, workers = min(future::availableCores(), jobs)),
-       gc = TRUE, earlySignal = TRUE)
+  plan(list(tweak(multiprocess, workers = min(future::availableCores(), jobs)), gc = TRUE, earlySignal = TRUE)
+            tweak(multiprocess, workers = max(1, round(future::availableCores() / jobs, 0)))))
   
   
   jobs <- max(1, round(future::availableCores() / jobs, 0))

--- a/rt-estimate/estimate/utils/run-rt-estimate.R
+++ b/rt-estimate/estimate/utils/run-rt-estimate.R
@@ -62,8 +62,8 @@ run_rt_estimate <- function(data,
                          return_estimates = FALSE, 
                          summary = TRUE,
                          return_timings = TRUE, 
-                         future = FALSE,
-                         max_execution_time = Inf)
+                         future = TRUE,
+                         max_execution_time = 60 * 60 * 5)
   
   futile.logger::flog.debug("resetting future plan to sequential")
   future::plan("sequential")


### PR DESCRIPTION
This PR is an example of using the new chain by chain timeout features in the latest version of `EpiNow2`. Not a suggestion it should be used here. If using the timeout should be set based on dropping outliers rather than the mean runtime (i.e if core usage is down to 1 with only a single region left adding a timeout at that point would make sense). In the global estimates we see that the model takes around 5 minutes to 1 hour to fit with anything over 2 hours being considered an outlying chain and killed. Obviously your experience will be different as running across a much larger time series. 